### PR TITLE
fix bug: when do general_log->set_file() will change the opt_slow_logname's value

### DIFF
--- a/sql/log.cc
+++ b/sql/log.cc
@@ -505,13 +505,16 @@ bool File_query_log::set_file(const char *new_name) {
 
   name = nn;
 
-  mysql_mutex_lock(&LOCK_log);
-  cur_log_ext = 0;
-  last_removed_ext = 0;
-  bool res = set_rotated_name(false) || purge_logs();
-  mysql_mutex_unlock(&LOCK_log);
+  if (m_log_type == QUERY_LOG_SLOW) {
+    mysql_mutex_lock(&LOCK_log);
+    cur_log_ext = 0;
+    last_removed_ext = 0;
+    bool res = set_rotated_name(false) || purge_logs();
+    mysql_mutex_unlock(&LOCK_log);
+    return res;
+  }
 
-  return res;
+  return false;
 }
 
 bool File_query_log::open() {


### PR DESCRIPTION
set_rotated_name will change opt_slow_logname.
But it will be called by set_file, and set_file will not only be called by slow_log but also general_log, which will cause an error to set the opt_slow_logname to general_log's rotate name. So fix this by compare its m_log_type